### PR TITLE
Use groupId for admin checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ buildNumber.properties
 
 # Docker Volumes
 dockervols/weblogs
+
+.fake

--- a/src/main/java/Controllers/Category.java
+++ b/src/main/java/Controllers/Category.java
@@ -75,7 +75,7 @@ public class Category extends HttpServlet {
         User u = (User) request.getSession().getAttribute("loggedUser");
 
         if (u != null) {
-            if (u.getId() == 1) {
+            if (u.getGroupId() == 1) {
                 hasPermission = true;
             }
         }
@@ -87,6 +87,7 @@ public class Category extends HttpServlet {
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         if (!this.HasPermission(request)) {
             request.getRequestDispatcher("/WEB-INF/JSPViews/CategoryView/NoPermission.jsp").forward(request, response);
+            return;
         }
 
         switch (request.getParameter("action")) {

--- a/src/main/java/Controllers/PostList.java
+++ b/src/main/java/Controllers/PostList.java
@@ -39,8 +39,8 @@ public class PostList extends HttpServlet {
         if (!this.IsAuthenticated(session)) {
             return false;
         }
-        
-        return (u.getId() == 1);
+
+        return (u.getGroupId() == 1);
     }
     
     private void CreatePost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {


### PR DESCRIPTION
Replace hardcoded user id checks with groupId checks for admin permission in Category and PostList (u.getId() -> u.getGroupId()). In Category.doGet, add a return after forwarding to NoPermission.jsp to prevent further processing. Also add .fake to .gitignore.